### PR TITLE
fix: replace non deterministic order data structure

### DIFF
--- a/cayenne-server/src/main/java/org/apache/cayenne/log/CompactSlf4jJdbcEventLogger.java
+++ b/cayenne-server/src/main/java/org/apache/cayenne/log/CompactSlf4jJdbcEventLogger.java
@@ -20,7 +20,7 @@ package org.apache.cayenne.log;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -108,7 +108,7 @@ public class CompactSlf4jJdbcEventLogger extends Slf4jJdbcEventLogger {
 
     @SuppressWarnings("unchecked")
     private Map<String, List<String>> collectBindings(ParameterBinding[] bindings) {
-        Map<String, List<String>> bindingsMap = new HashMap<>();
+        Map<String, List<String>> bindingsMap = new LinkedHashMap<>();
 
         String key = null;
         String value;


### PR DESCRIPTION
In this specific test: `org.apache.cayenne.log.CompactSlf4jJdbcEventLoggerTest.compactBindings`, usage of ```Hashmap``` creates uncertainty of key orders, causing assertions relying on the order to fail under unexpected running environment. 

Use ```LinkedHashMap``` to keep the hash property while maintaining some kind of ordering. 